### PR TITLE
Add version warning

### DIFF
--- a/docs/css/core.css
+++ b/docs/css/core.css
@@ -144,3 +144,12 @@ span.ratio-colon {
 	font-weight: bold;
 	margin-left: 0.2em;
 }
+
+div.notice {
+    border: 1rem ridge #e3a024;
+    background-color: #ba7e1e;
+}
+
+div.notice > * {
+	margin: 8px;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,6 +29,9 @@
 
 <body>
 	<a href="https://github.com/SeaRyanC/factorio-reference"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/e7bbb0521b397edbd5fe43e7f760759336b5e05f/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677265656e5f3030373230302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png"></a>
+	<div class="notice">
+		<h2>Outdated page</h2>
+		<p>This documentation is for the 0.16.16 version of Factorio, released in 2018. For more up to date info, see <a href="https://factoriocheatsheet.com">factoriocheatsheet.com</a>, or <a href="https://kirkmcdonald.github.io/calc">Factorio Calculator</a> for planning factories.</p></div>
 	<h1><a href="#belt-throughput">Throughput</a></h1>
 	<div class="annotated">
 		<div class="table">


### PR DESCRIPTION
As requested in #6.

Factorio version was guessed based on version history and last commit date. The latest version of Node had some complaints about the code (maybe defaulting to a new version of JS or TS? Not a Node dev; just guesses). Downgrading to 9.11.2 from 2018 worked as expected.

Wording and coloration are all just suggestions. I tried to find decent coloration to not look too saturated against the drab background, but in addition to not being a Node dev, I'm also not a graphic designer.